### PR TITLE
add " ' " around ticket id to make it a more valid JSON object

### DIFF
--- a/v2.0.1/mql4/DWX_ZeroMQ_Server_v2.0.1_RC8.mq4
+++ b/v2.0.1/mql4/DWX_ZeroMQ_Server_v2.0.1_RC8.mq4
@@ -827,7 +827,7 @@ void DWX_GetOpenOrders(string &zmq_ret) {
       
       if (OrderSelect(i,SELECT_BY_POS)==true) {
       
-         zmq_ret = zmq_ret + IntegerToString(OrderTicket()) + ": {";
+         zmq_ret = zmq_ret + "'" + IntegerToString(OrderTicket()) + "': {";
          
          zmq_ret = zmq_ret + "'_magic': " + IntegerToString(OrderMagicNumber()) + ", '_symbol': '" + OrderSymbol() + "', '_lots': " + DoubleToString(OrderLots()) + ", '_type': " + IntegerToString(OrderType()) + ", '_open_price': " + DoubleToString(OrderOpenPrice()) + ", '_open_time': '" + TimeToStr(OrderOpenTime(),TIME_DATE|TIME_SECONDS) + "', '_SL': " + DoubleToString(OrderStopLoss()) + ", '_TP': " + DoubleToString(OrderTakeProfit()) + ", '_pnl': " + DoubleToString(OrderProfit()) + ", '_comment': '" + OrderComment() + "'";
          


### PR DESCRIPTION
The TRADES is not a valid JSON because it is using ' and not ". This fix just add a ' around the ticket ID map so it can be parsed as JSON by replacing all ' with "